### PR TITLE
[+] Just a small dexor.py TypeError Fix 

### DIFF
--- a/dexor.py
+++ b/dexor.py
@@ -39,7 +39,7 @@ def main():
     if args.keyfile:
         key = bytearray(open(args.keyfile, 'rb').read())
     else:
-        key = bytearray(args.key)
+        key = bytearray(args.key, 'utf-8')
     offset = args.offset
 
     decdata = decode(data, key, offset)


### PR DESCRIPTION
fixed "`TypeError: string argument without an encoding`" on line 42

(I saved the original `dexor.py` as `dexor.py` and the modified as `dexor2.py`)
![image](https://github.com/hasherezade/crypto_utils/assets/68499986/084eb62e-9bc7-413f-b299-0fee3918e4d7)

and after the change:
From
```py
    else:
        key = bytearray(args.key)
    offset = args.offset
```

To
```py
    else:
        key = bytearray(args.key, 'utf-8')
    offset = args.offset
```

![image](https://github.com/hasherezade/crypto_utils/assets/68499986/6a03da42-32a9-4ead-9142-30aa37e6be18)

**If anything in this PR is wrong, please point it out!**
And yes I was in `/tmp/` folder, by accident I censored that folder name. `:)`


Wishes from Sweden!

//Will.

